### PR TITLE
Created history() method in products  to handle archive-view

### DIFF
--- a/app/Http/Controllers/BancassuranceController.php
+++ b/app/Http/Controllers/BancassuranceController.php
@@ -97,17 +97,9 @@ class BancassuranceController extends Controller
      */
     public function show(Bancassurance $bancassurance): View
     {
-        $history = Cache::tags($bancassurance->cacheTag())->remember("bancassurances:$bancassurance->id:history", 60*60*12, function () use ($bancassurance) {
-            return Bancassurance::where('code', '=', $bancassurance->code)
-                ->where('dist_short', '=', $bancassurance->dist_short)
-                ->where('code_owu', '=', $bancassurance->code_owu)
-                ->orderBy('edit_date', 'desc')->get();
-        });
-
         return view('products.bancassurances.show', [
             'title' => 'Szczegóły',
             'bancassurance' => $bancassurance,
-            'archive_bancassurances' => $history,
         ]);
     }
 

--- a/app/Http/Controllers/EmployeeController.php
+++ b/app/Http/Controllers/EmployeeController.php
@@ -95,15 +95,9 @@ class EmployeeController extends Controller
      */
     public function show(Employee $employee): View
     {
-        $history = Cache::remember("employees:$employee->id:history", 60*60*12, function () use ($employee) {
-            return Employee::where('name', '=', $employee->name)
-                ->orderBy('edit_date', 'desc')->get();
-        });
-
         return view('products.employees.show', [
             'title' => 'Szczegóły',
             'employee' => $employee,
-            'archive_employees' => $history,
         ]);
     }
 

--- a/app/Http/Controllers/InvestmentController.php
+++ b/app/Http/Controllers/InvestmentController.php
@@ -111,14 +111,9 @@ class InvestmentController extends Controller
      */
     public function show(Investment $investment): View
     {
-        $history = Cache::tags($investment->cacheTag())->remember($investment->cacheKey() . ":history", now()->addDays(7), function () use ($investment) {
-            return Investment::where('code_toil', '=', $investment->code_toil)->orderBy('edit_date', 'desc')->get();
-        });
-
         return view('products.investments.show', [
             'title' => 'Szczegóły',
             'investment' => $investment,
-            'archive_investments' => $history,
         ]);
     }
 

--- a/app/Http/Controllers/ProtectiveController.php
+++ b/app/Http/Controllers/ProtectiveController.php
@@ -103,17 +103,9 @@ class ProtectiveController extends Controller
      */
     public function show(Protective $protective): View|Factory|Application
     {
-        $history = Cache::remember("protectives:$protective->id:history", 60*60*12, function () use ($protective) {
-            return Protective::where('code', '=', $protective->code)
-                ->where('dist_short', '=', $protective->dist_short)
-                ->where('code_owu', '=', $protective->code_owu)
-                ->orderBy('edit_date', 'desc')->get();
-        });
-
         return view('products.protectives.show', [
             'title' => 'Szczegóły',
             'protective' => $protective,
-            'archive_protectives' => $history,
         ]);
     }
 

--- a/app/Models/Bancassurance.php
+++ b/app/Models/Bancassurance.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\MorphToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Facades\Cache;
 
 /**
  * @property int $id
@@ -104,6 +105,27 @@ class Bancassurance extends Model
     }
 
     /**
+     * Get the user that created the bancassurance.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo('App\Models\User');
+    }
+
+    /**
+     * @return array|mixed
+     */
+    public function history()
+    {
+        return Cache::tags($this->cacheTag())->remember($this->cacheKey() . ":history", now()->addDays(7), function () {
+            return Bancassurance::where('code', '=', $this->code)
+                ->where('dist_short', '=', $this->dist_short)
+                ->where('code_owu', '=', $this->code_owu)
+                ->orderBy('edit_date', 'desc')->get();
+        });
+    }
+
+    /**
      * Get unique name of the product.
      *
      * @return string
@@ -125,13 +147,5 @@ class Bancassurance extends Model
             'N' => 'Archiwalny',
             default => $this->attributes['status'],
         };
-    }
-
-    /**
-     * Get the user that created the bancassurance.
-     */
-    public function user(): BelongsTo
-    {
-        return $this->belongsTo('App\Models\User');
     }
 }

--- a/app/Models/Employee.php
+++ b/app/Models/Employee.php
@@ -83,6 +83,22 @@ class Employee extends Model
     }
 
     /**
+     * Get the user that created the employee.
+     */
+    public function user()
+    {
+        return $this->belongsTo('App\Models\User');
+    }
+
+    public function history()
+    {
+        return Cache::tags($this->cacheTag())->remember($this->cacheKey() . ":history", now()->addDays(7), function () {
+            return Employee::where('name', '=', $this->name)
+                ->orderBy('edit_date', 'desc')->get();
+        });
+    }
+
+    /**
      * Get unique name of the product.
      *
      * @return string
@@ -104,14 +120,6 @@ class Employee extends Model
             'N' => 'Archiwalny',
             default => $this->attributes['status'],
         };
-    }
-
-    /**
-     * Get the user that created the employee.
-     */
-    public function user()
-    {
-        return $this->belongsTo('App\Models\User');
     }
 
 }

--- a/app/Models/Investment.php
+++ b/app/Models/Investment.php
@@ -136,6 +136,16 @@ class Investment extends Model
     }
 
     /**
+     * @return array|mixed
+     */
+    public function history()
+    {
+        return Cache::tags($this->cacheTag())->remember($this->cacheKey() . ":history", now()->addDays(7), function () {
+            return Investment::where('code_toil', '=', $this->code_toil)->orderBy('edit_date', 'desc')->get();
+        });
+    }
+
+    /**
      * Get unique name of the product.
      *
      * @return string

--- a/app/Models/Protective.php
+++ b/app/Models/Protective.php
@@ -124,4 +124,14 @@ class Protective extends Model
         return $this->belongsTo('App\Models\User');
     }
 
+    public function history()
+    {
+        return Cache::tags($this->cacheTag())->remember($this->cacheKey() . ":history", now()->addDays(7), function () {
+            return Protective::where('code', '=', $this->code)
+                ->where('dist_short', '=', $this->dist_short)
+                ->where('code_owu', '=', $this->code_owu)
+                ->orderBy('edit_date', 'desc')->get();
+        });
+    }
+
 }

--- a/resources/views/products/bancassurances/show.blade.php
+++ b/resources/views/products/bancassurances/show.blade.php
@@ -48,7 +48,7 @@
 								<th class="min-w-100px"></th>
 							</x-slot>
 							<x-slot name="data">
-								@foreach($archive_bancassurances as $archive_bancassurance)
+								@foreach($bancassurance->history() as $archive_bancassurance)
 									<tr class="@if($archive_bancassurance->id == $bancassurance->id) bg-light @endif">
 										<td>{{ $archive_bancassurance->name }}</td>
 										<td>{{ $archive_bancassurance->dist_short }}</td>

--- a/resources/views/products/employees/show.blade.php
+++ b/resources/views/products/employees/show.blade.php
@@ -44,7 +44,7 @@
 								<th class="min-w-100px"></th>
 							</x-slot>
 							<x-slot name="data">
-								@foreach($archive_employees as $archive_employee)
+								@foreach($employee->history() as $archive_employee)
 									<tr class="@if($archive_employee->id == $employee->id) bg-light @endif">
 										<td>{{ $archive_employee->name }}</td>
 										<td>{{ $archive_employee->code_owu }}</td>

--- a/resources/views/products/investments/show.blade.php
+++ b/resources/views/products/investments/show.blade.php
@@ -55,7 +55,7 @@
 								<th class="min-w-100px"></th>
 							</x-slot>
 							<x-slot name="data">
-								@foreach($archive_investments as $archive_investment)
+								@foreach($investment->history() as $archive_investment)
 									<tr class="@if($archive_investment->id == $investment->id) bg-light @endif">
 										<td>{{ $archive_investment->name }}</td>
 										<td>{{ $archive_investment->code_toil }}</td>

--- a/resources/views/products/protectives/show.blade.php
+++ b/resources/views/products/protectives/show.blade.php
@@ -48,7 +48,7 @@
 								<th class="min-w-100px"></th>
 							</x-slot>
 							<x-slot name="data">
-								@foreach($archive_protectives as $archive_protective)
+								@foreach($protective->history() as $archive_protective)
 									<tr class="@if($archive_protective->id == $protective->id) bg-light @endif">
 										<td>{{ $archive_protective->name }}</td>
 										<td>{{ $archive_protective->dist_short }}</td>


### PR DESCRIPTION
Deleted from Controller:

```
        $history = Cache::tags($bancassurance->cacheTag())->remember("bancassurances:$bancassurance->id:history", 60*60*12, function () use ($bancassurance) {
            return Bancassurance::where('code', '=', $bancassurance->code)
                ->where('dist_short', '=', $bancassurance->dist_short)
                ->where('code_owu', '=', $bancassurance->code_owu)
                ->orderBy('edit_date', 'desc')->get();
        });
```

and moved to Model:

 ```
   /**
     * @return array|mixed
     */
    public function history()
    {
        return Cache::tags($this->cacheTag())->remember($this->cacheKey() . ":history", now()->addDays(7), function () {
            return Bancassurance::where('code', '=', $this->code)
                ->where('dist_short', '=', $this->dist_short)
                ->where('code_owu', '=', $this->code_owu)
                ->orderBy('edit_date', 'desc')->get();
        });
    }
```

next step is extended database to assign history products to active product.